### PR TITLE
TXMP-439 [DM] Widen conditional Content-Type filtering

### DIFF
--- a/middlewares/audittap/audittypes/api_auditing.go
+++ b/middlewares/audittap/audittypes/api_auditing.go
@@ -25,9 +25,9 @@ func (ev *APIAuditEvent) AppendRequest(ctx *RequestContext, auditSpec *AuditSpec
 		if &auditSpec.AuditObfuscation != nil {
 			ct := ctx.FlatHeaders.GetString("content-type")
 			var fnObfuscate func(b []byte) ([]byte, error)
-			if ct == "application/x-www-form-urlencoded" {
+			if strings.HasPrefix(ct, "application/x-www-form-urlencoded") {
 				fnObfuscate = auditSpec.AuditObfuscation.ObfuscateURLEncoded
-			} else if ct == "application/json" {
+			} else if strings.HasPrefix(ct, "application/json") {
 				fnObfuscate = auditSpec.AuditObfuscation.ObfuscateJSON
 			}
 			if fnObfuscate != nil {

--- a/middlewares/audittap/audittypes/api_auditing_test.go
+++ b/middlewares/audittap/audittypes/api_auditing_test.go
@@ -88,7 +88,7 @@ func TestFormEncodedContentMasking(t *testing.T) {
 
 	ev := APIAuditEvent{}
 	req := httptest.NewRequest("POST", "/some/api/resource?p1=v1", strings.NewReader(requestBody))
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded; charset=ISO-8859-1")
 
 	obfuscate := AuditObfuscation{MaskFields: []string{"password", "secret"}, MaskValue: "@@@"}
 	spec := &AuditSpecification{}
@@ -113,7 +113,7 @@ func TestJsonContentMasking(t *testing.T) {
 
 	ev := APIAuditEvent{}
 	req := httptest.NewRequest("POST", "/some/api/resource?p1=v1", strings.NewReader(requestBody))
-	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Content-Type", "application/json; charset=UTF-8")
 
 	obfuscate := AuditObfuscation{MaskFields: []string{"password", "secret"}, MaskValue: "@@@"}
 	spec := &AuditSpecification{}


### PR DESCRIPTION
- Change conditional auditing logic based on Content-Type to use type starts
with instead of exact match

<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Make sure all tests pass.
- Add tests.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/containous/traefik/blob/master/CONTRIBUTING.md.

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->


### Motivation

<!-- What inspired you to submit this pull request? -->


### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
