### PR TITLE
[DLK-238] Handle no trailing slash in the Forward-Prefix

### DIFF
--- a/middlewares/audittap/audittypes/api_auditing.go
+++ b/middlewares/audittap/audittypes/api_auditing.go
@@ -68,6 +68,9 @@ func NewAPIAuditEvent(auditSource string, auditType string) Auditer {
 
 func (ev *APIAuditEvent) defineRequestPath(ctx *RequestContext) {
 	if forwardPrefix := ctx.FlatHeaders.GetString("x-forwarded-prefix"); strings.HasPrefix(ev.Path, apiGatewayPathPrefix) && forwardPrefix != "" {
+		if !strings.HasSuffix(forwardPrefix, "/") {
+			forwardPrefix = forwardPrefix + "/"
+		}
 		inferredPath := strings.Replace(ev.Path, apiGatewayPathPrefix, forwardPrefix, 1)
 		ev.ProxiedPath = ev.Path
 		ev.Path = inferredPath

--- a/middlewares/audittap/audittypes/api_auditing_test.go
+++ b/middlewares/audittap/audittypes/api_auditing_test.go
@@ -68,6 +68,20 @@ func TestApiGatewayPrefixRulePathChange(t *testing.T) {
 	assert.Equal(t, "p1=v1", ev.QueryString)
 }
 
+func TestApiGatewayPrefixRulePathChangeWithoutTrailingSlash(t *testing.T) {
+
+	ev := APIAuditEvent{}
+	req := httptest.NewRequest("POST", "/current/api/resource?p1=v1", nil)
+	req.Header.Set("X-Forwarded-Prefix", "/the/actual/service")
+
+	spec := &AuditSpecification{}
+	ev.AppendRequest(NewRequestContext(req), spec)
+
+	assert.Equal(t, "/the/actual/service/api/resource", ev.Path)
+	assert.Equal(t, "/current/api/resource", ev.ProxiedPath)
+	assert.Equal(t, "p1=v1", ev.QueryString)
+}
+
 func TestDefinePathReplacementOnlyIsForPrefix(t *testing.T) {
 
 	ev := APIAuditEvent{}


### PR DESCRIPTION
Bug: A change to the api-gateway to support urls without a trailing slash
lead to the removal of the trailing slash in the X-Forward-Prefix header
which mean that when the original path was reconstructed from the
X-Forward-Prefix header /current/ was replaced with a value with no
trailing slash so the separator between vat and the vrn was removed
resulting in values like .../vat3211321/...

This change adds a '/' if none is present so it should handle both cases.

Note:
 - This is only needed because the auditing occurs after the orignal
   path is modified to add the Accept-Version.

 - We are trying to maintain a stable path that is not modified by
   internal changes to routing so the go code tries to consitently
   create a path of `/<version>/<original-path>`
