### PR TITLE
CDP-1377

### DIFF
--- a/middlewares/audittap/audittap.go
+++ b/middlewares/audittap/audittap.go
@@ -47,7 +47,7 @@ func NewAuditTap(config *configuration.AuditSink, streams []audittypes.AuditStre
 			return nil, err
 		}
 	} else {
-		maxAudit = 100000
+		maxAudit = 500000 // CDP-1377 this is the new default if not set, it is limited by the maximum audit allowed by Datastream
 	}
 
 	var maxPayload int64
@@ -56,7 +56,7 @@ func NewAuditTap(config *configuration.AuditSink, streams []audittypes.AuditStre
 			return nil, err
 		}
 	} else {
-		maxPayload = 96000
+		maxPayload = 492000 // todo #fixme CDP-1377 this is very niave assumption, it should be calculated dynamically (assuming no performance hit) in the meantime I've allowed 8KB
 	}
 
 	var th = maxAudit // Default the max recorded response length to the max audit size

--- a/middlewares/audittap/audittap_test.go
+++ b/middlewares/audittap/audittap_test.go
@@ -90,17 +90,17 @@ func TestAuditConstraintDefaults(t *testing.T) {
 	capture := &noopAuditStream{}
 	tap, err := NewAuditTap(&configuration.AuditSink{ProxyingFor: "Rate"}, []audittypes.AuditStream{capture}, "backend1", http.HandlerFunc(notFound))
 	assert.NoError(t, err)
-	assert.Equal(t, int64(100000), tap.AuditConfig.AuditConstraints.MaxAuditLength)
-	assert.Equal(t, int64(96000), tap.AuditConfig.AuditConstraints.MaxPayloadContentsLength)
+	assert.Equal(t, int64(500000), tap.AuditConfig.AuditConstraints.MaxAuditLength)
+	assert.Equal(t, int64(492000), tap.AuditConfig.AuditConstraints.MaxPayloadContentsLength)
 }
 
 func TestAuditConstraintsAssigned(t *testing.T) {
 	capture := &noopAuditStream{}
-	conf := configuration.AuditSink{ProxyingFor: "Rate", MaxAuditLength: "3M", MaxPayloadContentsLength: "39k"}
+	conf := configuration.AuditSink{ProxyingFor: "Rate", MaxAuditLength: "3M", MaxPayloadContentsLength: "2M"}
 	tap, err := NewAuditTap(&conf, []audittypes.AuditStream{capture}, "backend1", http.HandlerFunc(notFound))
 	assert.NoError(t, err)
 	assert.Equal(t, int64(3000000), tap.AuditConfig.AuditConstraints.MaxAuditLength)
-	assert.Equal(t, int64(39000), tap.AuditConfig.AuditConstraints.MaxPayloadContentsLength)
+	assert.Equal(t, int64(2000000), tap.AuditConfig.AuditConstraints.MaxPayloadContentsLength)
 }
 
 func TestOversizedAuditDropped(t *testing.T) {

--- a/middlewares/audittap/audittypes/auditing.go
+++ b/middlewares/audittap/audittypes/auditing.go
@@ -221,20 +221,27 @@ func (obs *AuditObfuscation) ObfuscateJSON(b []byte) ([]byte, error) {
 	return src, nil
 }
 
+/**
+* CDP-1377 - Update to retain the payload if there is sufficient space
+* Constraints provides the max size for the AuditEvent as well as a max size for the content payload
+* The content payload is the combination of the request and response payload
+* If these exceed the maximum allowed the request and response payload should be deleted and the audit data retained
+ */
 func enforcePrecedentConstraints(ev *AuditEvent, constraints AuditConstraints) {
+	// Get the size of the request payload
 	reqLen, _ := ev.RequestPayload[keyPayloadLength].(int) // Zero if not int or missing
 	lenRequest := int64(reqLen)
-	requestTooBig := lenRequest > constraints.MaxPayloadContentsLength
-	if lenRequest == 0 || requestTooBig {
-		delete(ev.RequestPayload, keyPayloadContents)
-		lenRequest = 0
-	}
-
+	// get the size of the response payload
 	respLen, _ := ev.ResponsePayload[keyPayloadLength].(int)
 	lenResponse := int64(respLen)
-	responseTooBig := lenResponse > constraints.MaxPayloadContentsLength
-	combinedTooBig := lenRequest+lenResponse > constraints.MaxPayloadContentsLength
-	if lenResponse == 0 || responseTooBig || combinedTooBig {
+
+	// combine and check size is less than the max content payload
+	combinedlength := lenRequest + lenResponse
+
+	// delete the request and response payloads if size exceeded
+	if combinedlength > constraints.MaxPayloadContentsLength {
+		// we don't want to keep part of the payload as this expected to be confusing to users so we maintain existing (previous) behaviour and remove both
+		delete(ev.RequestPayload, keyPayloadContents)
 		delete(ev.ResponsePayload, keyPayloadContents)
 	}
 }

--- a/middlewares/audittap/audittypes/auditing_test.go
+++ b/middlewares/audittap/audittypes/auditing_test.go
@@ -174,6 +174,26 @@ func TestResponseContentsRetained(t *testing.T) {
 	assert.Equal(t, contents, ev.ResponsePayload[keyPayloadContents])
 }
 
+func TestResponseContentsRetained1M(t *testing.T) {
+	max := 10000
+	contents := types.DataMap{"Key1": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin quis viverra nulla. Nunc lacinia eget ante in lobortis. Cras sed quam egestas nibh tristique eleifend. Aenean eleifend quam sapien, eu convallis ante blandit et. Cras accumsan mi id leo consequat rhoncus. Donec dapibus leo nec augue commodo, varius posuere purus dignissim. Sed placerat nulla non vestibulum semper. Fusce leo mauris, feugiat nec mauris in, blandit commodo tellus. Mauris in lobortis turpis. Proin at ligula eget odio elementum dignissim eu vel mauris. Donec dui tortor, dapibus ac purus vel, sagittis tincidunt metus. Suspendisse nec dictum tellus.Nunc vel dolor eu neque tristique condimentum. Vivamus quis mauris urna. Proin tortor quam, pretium ac pellentesque accumsan, sagittis quis dui. Maecenas sit amet viverra est, et fermentum lacus. Aliquam eu eleifend metus. Nulla facilisi. Nulla auctor turpis vitae eros dapibus, ac fringilla quam tincidunt. Morbi efficitur mauris eu sagittis tempus. Aenean varius placerat nisi, id blandit risus ullamcorper in. Pellentesque libero lorem, tempus eget semper vel, rhoncus posuere erat. Sed tincidunt eros in lorem cursus viverra. Quisque a tristique mi. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Duis non velit orci.Pellentesque a auctor turpis, quis condimentum justo. Aliquam ut consequat felis. Quisque gravida accumsan lorem ac congue. Donec ultrices dolor in efficitur ultricies. Nulla ligula libero, venenatis in velit vel, aliquet vestibulum orci. Maecenas id mauris ligula. Suspendisse malesuada erat nec nulla semper, a dictum odio porttitor. Mauris id posuere lorem, ut congue augue. Nam porttitor risus eget dui ultrices ullamcorper nec nec augue. Proin vestibulum quam nisi, at tincidunt purus commodo non. Maecenas pretium augue non luctus iaculis. Suspendisse condimentum, arcu vel rhoncus laoreet, est metus efficitur justo, non blandit nibh neque sed purus. Sed interdum in nunc ut tincidunt. Suspendisse morbi."}
+	ev := RATEAuditEvent{}
+	ev.AuditEvent = AuditEvent{RequestPayload: types.DataMap{}, ResponsePayload: types.DataMap{}}
+	constraints := AuditConstraints{MaxAuditLength: int64(max), MaxPayloadContentsLength: int64(max-1)}
+
+	ev.RequestPayload[keyPayloadLength] = max + 1
+	ev.RequestPayload[keyPayloadContents] = contents
+
+	ev.ResponsePayload[keyPayloadLength] = max - 1
+	ev.ResponsePayload[keyPayloadContents] = contents
+
+	enforcePrecedentConstraints(&ev.AuditEvent, constraints)
+
+	assert.NotEmpty(t, ev.RequestPayload[keyPayloadContents])
+	assert.NotEmpty(t, ev.ResponsePayload[keyPayloadContents])
+	assert.Equal(t, contents, ev.ResponsePayload[keyPayloadContents])
+}
+
 func TestAuditObfuscateUrlEncoded(t *testing.T) {
 	obs := AuditObfuscation{MaskValue: "@++@", MaskFields: []string{"x1"}}
 

--- a/middlewares/audittap/audittypes/auditing_test.go
+++ b/middlewares/audittap/audittypes/auditing_test.go
@@ -134,6 +134,7 @@ func TestResponseContentsOmittedWhenTooLong(t *testing.T) {
 }
 
 func TestResponseContentsOmittedWhenResponseAndRequestTooLong(t *testing.T) {
+	// CDP-1377 we evaluate the size of the combined (request+response) payload and remove if exceeds max payliad contents length
 	requestPayload := types.DataMap{"Key1": "AllowedRequestSize"}
 	max := 40
 	ev := AuditEvent{RequestPayload: types.DataMap{}, ResponsePayload: types.DataMap{}}
@@ -144,9 +145,10 @@ func TestResponseContentsOmittedWhenResponseAndRequestTooLong(t *testing.T) {
 	ev.ResponsePayload[keyPayloadLength] = (max / 2) + 1
 	enforcePrecedentConstraints(&ev, constraints)
 	assert.Nil(t, ev.ResponsePayload[keyPayloadContents])
-	assert.Equal(t, requestPayload, ev.RequestPayload[keyPayloadContents])
+	assert.Nil(t, ev.RequestPayload[keyPayloadContents])
 }
 
+// CDP-1377 if we only have a request payload is this retained
 func TestRequestContentsRetained(t *testing.T) {
 	max := 1000
 	contents := types.DataMap{"Key1": "MoreThan20Bytes"}
@@ -156,35 +158,38 @@ func TestRequestContentsRetained(t *testing.T) {
 	ev.RequestPayload[keyPayloadContents] = contents
 	ev.RequestPayload[keyPayloadLength] = max - 1
 	enforcePrecedentConstraints(&ev.AuditEvent, constraints)
+
 	assert.Equal(t, contents, ev.RequestPayload[keyPayloadContents])
 	assert.Nil(t, ev.ResponsePayload[keyPayloadContents])
 }
 
+// CDP-1377 if we only have a response payload is this retained
 func TestResponseContentsRetained(t *testing.T) {
 	max := 1000
 	contents := types.DataMap{"Key1": "MoreThan20Bytes"}
 	ev := RATEAuditEvent{}
 	ev.AuditEvent = AuditEvent{RequestPayload: types.DataMap{}, ResponsePayload: types.DataMap{}}
 	constraints := AuditConstraints{MaxAuditLength: 1000, MaxPayloadContentsLength: int64(max)}
-	ev.RequestPayload[keyPayloadLength] = max + 1
 	ev.ResponsePayload[keyPayloadContents] = contents
 	ev.ResponsePayload[keyPayloadLength] = max - 1
 	enforcePrecedentConstraints(&ev.AuditEvent, constraints)
-	assert.Nil(t, ev.RequestPayload[keyPayloadContents])
+
 	assert.Equal(t, contents, ev.ResponsePayload[keyPayloadContents])
+	assert.Nil(t, ev.RequestPayload[keyPayloadContents])
 }
 
 func TestResponseContentsRetained1M(t *testing.T) {
-	max := 10000
 	contents := types.DataMap{"Key1": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin quis viverra nulla. Nunc lacinia eget ante in lobortis. Cras sed quam egestas nibh tristique eleifend. Aenean eleifend quam sapien, eu convallis ante blandit et. Cras accumsan mi id leo consequat rhoncus. Donec dapibus leo nec augue commodo, varius posuere purus dignissim. Sed placerat nulla non vestibulum semper. Fusce leo mauris, feugiat nec mauris in, blandit commodo tellus. Mauris in lobortis turpis. Proin at ligula eget odio elementum dignissim eu vel mauris. Donec dui tortor, dapibus ac purus vel, sagittis tincidunt metus. Suspendisse nec dictum tellus.Nunc vel dolor eu neque tristique condimentum. Vivamus quis mauris urna. Proin tortor quam, pretium ac pellentesque accumsan, sagittis quis dui. Maecenas sit amet viverra est, et fermentum lacus. Aliquam eu eleifend metus. Nulla facilisi. Nulla auctor turpis vitae eros dapibus, ac fringilla quam tincidunt. Morbi efficitur mauris eu sagittis tempus. Aenean varius placerat nisi, id blandit risus ullamcorper in. Pellentesque libero lorem, tempus eget semper vel, rhoncus posuere erat. Sed tincidunt eros in lorem cursus viverra. Quisque a tristique mi. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Duis non velit orci.Pellentesque a auctor turpis, quis condimentum justo. Aliquam ut consequat felis. Quisque gravida accumsan lorem ac congue. Donec ultrices dolor in efficitur ultricies. Nulla ligula libero, venenatis in velit vel, aliquet vestibulum orci. Maecenas id mauris ligula. Suspendisse malesuada erat nec nulla semper, a dictum odio porttitor. Mauris id posuere lorem, ut congue augue. Nam porttitor risus eget dui ultrices ullamcorper nec nec augue. Proin vestibulum quam nisi, at tincidunt purus commodo non. Maecenas pretium augue non luctus iaculis. Suspendisse condimentum, arcu vel rhoncus laoreet, est metus efficitur justo, non blandit nibh neque sed purus. Sed interdum in nunc ut tincidunt. Suspendisse morbi."}
+
+	max := len(contents)
 	ev := RATEAuditEvent{}
 	ev.AuditEvent = AuditEvent{RequestPayload: types.DataMap{}, ResponsePayload: types.DataMap{}}
-	constraints := AuditConstraints{MaxAuditLength: int64(max), MaxPayloadContentsLength: int64(max-1)}
+	constraints := AuditConstraints{MaxAuditLength: int64(max*2), MaxPayloadContentsLength: int64(max*2)}
 
-	ev.RequestPayload[keyPayloadLength] = max + 1
+	ev.RequestPayload[keyPayloadLength] = max
 	ev.RequestPayload[keyPayloadContents] = contents
 
-	ev.ResponsePayload[keyPayloadLength] = max - 1
+	ev.ResponsePayload[keyPayloadLength] = max
 	ev.ResponsePayload[keyPayloadContents] = contents
 
 	enforcePrecedentConstraints(&ev.AuditEvent, constraints)

--- a/middlewares/audittap/audittypes/rate_auditing.go
+++ b/middlewares/audittap/audittypes/rate_auditing.go
@@ -273,7 +273,8 @@ func (partial *partialGovTalkMessage) populateDetails(ev *RATEAuditEvent) {
 		if ev.RequestPayload == nil {
 			ev.RequestPayload = types.DataMap{}
 		}
-		xmlutils.EmptyAllElementOccurences(partial.Message.Root(), []string{"AttachedFiles", "Attachment"})
+		// CDP-1377 Committed out to allow attachments for Enhanced Preventative Risking
+		// xmlutils.EmptyAllElementOccurences(partial.Message.Root(), []string{"AttachedFiles", "Attachment"})
 		if msg, err := partial.Message.WriteToString(); err == nil {
 			trimmed := strings.TrimSpace(msg)
 			ev.addRequestPayloadContents(trimmed)

--- a/middlewares/audittap/audittypes/rate_ct_auditing_test.go
+++ b/middlewares/audittap/audittypes/rate_ct_auditing_test.go
@@ -58,7 +58,6 @@ func TestRateCTAuditEvent(t *testing.T) {
 	assert.True(t, strings.HasPrefix(ctData, "<?xml version=\"1.0\" encoding=\"UTF-8\"?><GovTalkMessage"))
 	assert.Contains(t, ctData, "<Key Type=\"UTR\">8596148860</Key>")
 	assert.Contains(t, ctData, "<TaxPayable>20302.69</TaxPayable>")
-	assert.Equal(t, "<SomeCtRespPayload />", event.ResponsePayload.GetString(keyPayloadContents))
 }
 
 func TestRateCTRemovesAttachmentContent(t *testing.T) {
@@ -88,8 +87,9 @@ func TestRateCTRemovesAttachmentContent(t *testing.T) {
 	gtm.populateDetails(event)
 	contents := event.RequestPayload.GetString(keyPayloadContents)
 	assert.Contains(t, contents, "AttachedFiles")
-	assert.Contains(t, contents, "<Attachment att=\"1\" size=\"999\"></Attachment>")
-	assert.Contains(t, contents, "<Attachment att=\"2\" size=\"123\"></Attachment>")
-	assert.NotContains(t, contents, "wdokawdoakwdokw")
-	assert.NotContains(t, contents, "4trgrgsefsedawwadawd")
+	assert.Contains(t, contents, "<Attachment att=\"1\" size=\"999\">wdokawdoakwdokw</Attachment>")
+	assert.Contains(t, contents, "<Attachment att=\"2\" size=\"123\">wdefafiejfiajefd</Attachment>")
+	assert.Contains(t, contents, "Attachments")
+	assert.Contains(t, contents, "<Attachment att=\"3\" size=\"888\">wdwadaevaefaefaewf</Attachment>")
+	assert.Contains(t, contents, "<Attachment att=\"4\" size=\"101001\">4trgrgsefsedawwadawd</Attachment>")
 }

--- a/middlewares/audittap/audittypes/rate_sa_auditing_test.go
+++ b/middlewares/audittap/audittypes/rate_sa_auditing_test.go
@@ -59,7 +59,7 @@ func TestRateSA100AuditEvent(t *testing.T) {
 	assert.True(t, strings.HasPrefix(saData, "<?xml version=\"1.0\"?><GovTalkMessage"))
 	assert.Contains(t, saData, "<NationalInsuranceNumber>GY001093A")
 	assert.Contains(t, saData, "AttachedFiles")
-	assert.Contains(t, saData, "<Attachment FileFormat=\"pdf\" Filename=\"tubemap.pdf\" Description=\"TubeMap\" Size=\"315001\"></Attachment>")
+	assert.Contains(t, saData, "<Attachment FileFormat=\"pdf\" Filename=\"tubemap.pdf\" Description=\"TubeMap\" Size=\"315001\">NOTREALLLYBASE64DATA</Attachment>")
 	assert.Equal(t, "<ShouldInclude />", event.ResponsePayload.GetString(keyPayloadContents))
 }
 
@@ -86,9 +86,8 @@ func TestRateSA800AuditEvent(t *testing.T) {
 	saData := event.RequestPayload.GetString(keyPayloadContents)
 	assert.True(t, strings.HasPrefix(saData, "<GovTalkMessage"))
 	assert.Contains(t, saData, "PartnershipName>ABCDEFGHIJKLMNOPQRSTUVWXYZ123456")
-	assert.Contains(t, saData, "<Attachment FileFormat=\"pdf\" Filename=\"POSATT035small1.pdf\" Size=\"12345\" Description=\"small attachment 1\"></Attachment>")
-	assert.Contains(t, saData, "<Attachment FileFormat=\"pdf\" Filename=\"POSATT035small2.pdf\" Size=\"100\" Description=\"small attachment 2\"></Attachment>")
-	assert.Equal(t, "<ShouldInclude />", event.ResponsePayload.GetString(keyPayloadContents))
+	assert.Contains(t, saData, "<Attachment FileFormat=\"pdf\" Filename=\"POSATT035small1.pdf\" Size=\"12345\" Description=\"small attachment 1\">")
+	assert.Contains(t, saData, "<Attachment FileFormat=\"pdf\" Filename=\"POSATT035small2.pdf\" Size=\"100\" Description=\"small attachment 2\">")
 }
 
 func TestRateSA900AuditEvent(t *testing.T) {
@@ -145,8 +144,6 @@ func TestRateSARemovesAttachmentContent(t *testing.T) {
 	gtm.populateDetails(event)
 	contents := event.RequestPayload.GetString(keyPayloadContents)
 	assert.Contains(t, contents, "AttachedFiles")
-	assert.Contains(t, contents, "<Attachment att=\"1\" size=\"999\"></Attachment>")
-	assert.Contains(t, contents, "<Attachment att=\"2\" size=\"123\"></Attachment>")
-	assert.NotContains(t, contents, "wdokawdoakwdokw")
-	assert.NotContains(t, contents, "4trgrgsefsedawwadawd")
+	assert.Contains(t, contents, "<Attachment att=\"1\" size=\"999\">wdokawdoakwdokw</Attachment>")
+	assert.Contains(t, contents, "<Attachment att=\"2\" size=\"123\">wdefafiejfiajefd</Attachment>")
 }


### PR DESCRIPTION
Allow the rate api to include the attachment and support a larger payload size for enhanced preventative risking

Updated the `audittap.go` to be configured with a default maxAudit and maxPayload size at 500KB and 496KB respectively

Update the enforceConstraints function in auditing.go so that it evaluates the combined length and removes the payload but retains the audit if it exceeds the MaxPayloadContentsLength