### PR TITLE
Changes to support capturing more payload types for RATE

### DIFF
--- a/middlewares/audittap/audittypes/rate_auditing.go
+++ b/middlewares/audittap/audittypes/rate_auditing.go
@@ -156,7 +156,7 @@ func gtmGetMessageParts(decoder *xml.Decoder, path string, message io.Reader) (*
 				if doc, err := xmlutils.ElementInnerToDocument(&se, decoder); err == nil {
 					partial.Header = doc
 					if el := doc.FindElementPath(gtmClass); el != nil {
-						isSubmission = auditsRequestPayloadContents(el.Text()) && path == "/submission"
+						isSubmission = auditsRequestPayloadContents(el.Text()) && strings.HasSuffix(path, "/submission")
 					}
 				}
 			} else if se.Name.Local == "GovTalkDetails" {

--- a/middlewares/audittap/audittypes/rate_auditing.go
+++ b/middlewares/audittap/audittypes/rate_auditing.go
@@ -283,7 +283,16 @@ func (partial *partialGovTalkMessage) populateDetails(ev *RATEAuditEvent) {
 }
 
 func auditsRequestPayloadContents(auditType string) bool {
-	return strings.HasPrefix(auditType, "HMRC-SA-") || strings.HasPrefix(auditType, "HMRC-VAT-") || strings.HasPrefix(auditType, "HMRC-CT-")
+	return strings.HasPrefix(auditType, "HMRC-SA-") ||
+		strings.HasPrefix(auditType, "IR-AA-SA") ||
+		strings.HasPrefix(auditType, "HMRC-VAT-") ||
+		strings.HasPrefix(auditType, "HMRC-CT-") ||
+		strings.HasPrefix(auditType, "IR-AA-CT") ||
+		strings.HasPrefix(auditType, "IR-CTF-annnualReturn") ||
+		strings.HasPrefix(auditType, "HMRC-PAYE-") ||
+		strings.HasPrefix(auditType, "IR-PAYE-") ||
+		strings.HasPrefix(auditType, "HMRC-CHAR-CLM") ||
+		strings.HasPrefix(auditType, "HMRC-PP-PRAC-DEAUTH")
 }
 
 func extractMoneyValue(doc *etree.Document, path etree.Path) (float64, error) {


### PR DESCRIPTION
This change will extend the list of allowed
audit types that we can capture for RATE
XML submissions, assuming that the max
payload size and max audit size have been
set to larger than the content length